### PR TITLE
Update solidus_support to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated solidus_support to 0.4.0 for Zeitwerk and Rails 6 compatibility
+
 ## [0.2.0] - 2019-12-16
 
 ### Added

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.erb
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.erb
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'solidus_core' # Set Solidus version
+  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  s.add_dependency 'solidus_support', '~> 0.4.0'
 
   s.add_development_dependency 'solidus_dev_support'
 end

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 require 'solidus_core'
+require 'solidus_support'
+
 require '<%=file_name%>/engine'

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
+require 'spree/core'
+
 module <%= class_name %>
   class Engine < Rails::Engine
-    require 'spree/core'
+    include SolidusSupport::EngineExtensions::Decorators
+
     isolate_namespace Spree
+
     engine_name '<%= file_name %>'
 
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec
     end
-
-    def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
-    end
-
-    config.to_prepare(&method(:activate).to_proc)
   end
 end

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.36'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.3.3'
+  spec.add_dependency 'solidus_support', '~> 0.4.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary

Updates the version of solidus_support included in new extensions to 0.4.0, in order to add support for autoloading decorators on Zeitwerk and Rails 6.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
