### PR TITLE
Use local gem to run feature spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Gemfile.lock
 
 # rspec failure tracking
 .rspec_status
+
+/spec/tmp/

--- a/lib/solidus_dev_support/templates/extension/Gemfile
+++ b/lib/solidus_dev_support/templates/extension/Gemfile
@@ -20,6 +20,4 @@ else
   gem 'sqlite3'
 end
 
-gem 'solidus_dev_support', github: 'solidusio-contrib/solidus_dev_support'
-
 gemspec


### PR DESCRIPTION
## Summary

By running the feature spec with the local gem, we ensure we're actually testing the latest version of the code instead of the version on RubyGems.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [ ] ~I have added an entry to the changelog for this change.~ (Not relevant, since it's a dev change.)