### PR TITLE
Remove solidus_support dependency from gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Remove solidus_support gemspec dependency
 - Updated solidus_support to 0.4.0 for Zeitwerk and Rails 6 compatibility
 
 ## [0.2.0] - 2019-12-16

--- a/lib/solidus_dev_support.rb
+++ b/lib/solidus_dev_support.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "solidus_support"
 require "solidus_dev_support/version"
 
 module SolidusDevSupport
@@ -9,7 +8,7 @@ module SolidusDevSupport
   class << self
     def reset_spree_preferences_deprecated?
       first_version_without_reset = Gem::Requirement.new('>= 2.9')
-      first_version_without_reset.satisfied_by?(SolidusSupport.solidus_gem_version)
+      first_version_without_reset.satisfied_by?(Spree.solidus_gem_version)
     end
   end
 end

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.36'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.4.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary

There's no need to require this gem here. If needed, this should stay in the extension `gemspec` itself.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
