### PR TITLE
Stick to a single target Ruby version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Adopted Ruby 2.4+ as the minimum Ruby version in generated extensions
+
 ### Changed
 
 - Removed solidus_support gemspec dependency

--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -180,6 +180,7 @@ require:
   - rubocop-performance
 
 AllCops:
+  TargetRubyVersion: 2.4
   Exclude:
     - spec/dummy/**/*
     - vendor/**/*

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.erb
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.erb
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   # s.email     = 'you@example.com'
   # s.homepage  = 'http://www.example.com'
 
+  s.required_ruby_version = '~> 2.4'
+
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 

--- a/lib/solidus_dev_support/templates/extension/rubocop.yml
+++ b/lib/solidus_dev_support/templates/extension/rubocop.yml
@@ -5,7 +5,6 @@ inherit_gem:
   solidus_dev_support: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
   Exclude:
     - spec/dummy/**/*
     - vendor/**/*


### PR DESCRIPTION
Fixes #8.

## Summary

Sets the `TargetRubyVersion` in the generated RuboCop configuration and the `required_ruby_version` in the generated gemspec, so that we ensure all extensions support Ruby 2.4+, as Solidus does.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
