### PR TITLE
Improve documentation for extension Rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ further configuration and usage instructions.
 
 ### Rake tasks
 
-Put this in your `Rakefile`:
+To install extension-related Rake tasks, add this to your `Rakefile`:
 
 ```rb
 require 'solidus_dev_support/rake_tasks'
@@ -148,6 +148,14 @@ SolidusDevSupport::RakeTasks.install
 
 task default: 'extension:specs'
 ```
+
+(If your extension used the legacy extension Rakefile, then you should completely replace its
+contents with the block above.)
+
+This will provide the following tasks:
+
+- `extension:specs` (default), which runs the specs for your extension
+- `extension:test_app`, which generates a dummy app for your extension
 
 ## Development
 


### PR DESCRIPTION
Fixes #42.

## Summary

Improves the documentation around our Rake task, specifying that you should add the code to your Rakefile and replace it with any previous extension-related task configuration.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [ ] ~I have added an entry to the changelog for this change.~
