### PR TITLE
Use the full path to mark bin files executable

### DIFF
--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -22,8 +22,13 @@ module SolidusDevSupport
       directory '.circleci', "#{path}/.circleci"
       directory '.github', "#{path}/.github"
 
-      Dir["#{file_name}/bin/*"].each do |executable|
-        make_executable executable
+      %w[
+        bin/console
+        bin/rails
+        bin/setup
+      ].each do |bin|
+        template bin, "#{path}/#{bin}"
+        make_executable "#{path}/#{bin}"
       end
 
       template 'extension.gemspec.erb', "#{path}/#{file_name}.gemspec"

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe 'Create extension' do # rubocop:disable Metrics/BlockLength
       expect(output).to include(gemspec_name)
       expect(output).to include('.circleci')
     end
+
+    cd(install_path) do
+      %w[
+        bin/setup
+        bin/rails
+        bin/console
+      ].each do |bin|
+        bin = Pathname(bin)
+        expect(bin.exist?).to eq(true)
+        expect(bin.stat.executable?).to eq(true)
+      end
+    end
   end
 
   def check_bundle_install


### PR DESCRIPTION
## Summary

@spaghetticode reported that, while upgrading, the use of the relative `file_name` was leaving bin/ files not executable.

- use path instead of file_name to avoid relative paths
- Test the bin/ files are executable
- Explicitly list bin/files, this should make it more obvious what
happened if we break something in the future.

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
- [ ] I have added an entry to the changelog for this change.
