### PR TITLE
Require versionfile in generated extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed the generated RuboCop config inheriting from this gem's dev-only config
+- Fixed the generated extension not requiring the `version` file
 
 ## [0.4.0] - 2020-01-10
 

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
@@ -3,4 +3,5 @@
 require 'solidus_core'
 require 'solidus_support'
 
+require '<%=file_name%>/version'
 require '<%=file_name%>/engine'


### PR DESCRIPTION
## Summary

Adds a `require 'extension_name/version'` to the main Ruby file.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
