### PR TITLE
Fix generated RuboCop config inheriting from the wrong file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the generated RuboCop config inheriting from this gem's dev-only config
+
 ## [0.4.0] - 2020-01-10
 
 ### Added

--- a/lib/solidus_dev_support/templates/extension/rubocop.yml
+++ b/lib/solidus_dev_support/templates/extension/rubocop.yml
@@ -1,14 +1,2 @@
 require:
   - solidus_dev_support/rubocop
-
-inherit_gem:
-  solidus_dev_support: .rubocop.yml
-
-AllCops:
-  Exclude:
-    - spec/dummy/**/*
-    - vendor/**/*
-
-Rails/SkipsModelValidations:
-  Exclude:
-    - db/migrate/**/*


### PR DESCRIPTION
## Summary

Fixes the generated RuboCop config still leaning on the gem's own `.rubocop.yml`.

In new versions of solidus_dev_support, everything is configured with a simple `require` statement in the extension's `.rubocop.yml`, no need for other configurations.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
